### PR TITLE
Add a CVE description field.

### DIFF
--- a/cve_lookup/cve.py
+++ b/cve_lookup/cve.py
@@ -8,6 +8,7 @@ class cve():
     cvss2v = None
     cvss3 = None
     cvss2 = None
+    desc = None
 
     def _get_id(self, html, id, testid=True):
         try:
@@ -30,4 +31,5 @@ class cve():
         self.id = self._get_id(nvd_html, "page-header-vuln-id")
         self.cvss3v = self._get_id(nvd_html, "vuln-cvss3-nist-vector")
         self.cvss2v = self._get_id(nvd_html, "vuln-cvss2-panel-vector")
+        self.desc = self._get_id(nvd_html, "vuln-analysis-description")
         self.cvss2 = vector.cvss2_vector(self.cvss2v)


### PR DESCRIPTION
## test.py
```
#!/usr/bin/env python3
from cve_lookup import cve
target_cve = cve('CVE-2015-3636')
print(target_cve.id)
print(target_cve.cvss2v)
print(target_cve.desc)
```

## result of test
```
$ ./test.py
CVE-2015-3636
(AV:L/AC:L/Au:N/C:N/I:N/A:C)
The ping_unhash function in net/ipv4/ping.c in the Linux kernel before 4.0.3 does not initialize a certain list data structure during an unhash operation, which allows local users to gain privileges or cause a denial of service (use-after-free and system crash) by leveraging the ability to make a SOCK_DGRAM socket system call for the IPPROTO_ICMP or IPPROTO_ICMPV6 protocol, and then making a connect system call after a disconnect.
```